### PR TITLE
fix: parser error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,12 @@
 {
-  "plugins": [
-    "disable"
-  ],
+  "plugins": ["disable"],
   "processor": "disable/disable",
-  "parser": "@babel/eslint-parser"
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2020": true
+  }
 }


### PR DESCRIPTION
removing `"parser": "@babel/eslint-parser"` & enabling env